### PR TITLE
Add Github Commit Status Check to Alertlib.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOOGLE_API_CLIENT_DIR=.
 
 # Note we do not enable testing appengine mail on python3, since the
 # appengine libs are python2-only.
-check:
+check: dev-deps
 	export APPLICATION_ID=dev~khan-academy; \
 	for f in tests/*_test.py; do \
 	   echo "------ $$f PYTHON2" && env PYTHONPATH=${GOOGLE_API_CLIENT_DIR}:${APPENGINE_DIR}:$$PYTHONPATH python2 "$$f" && \
@@ -12,3 +12,6 @@ check:
 
 deps:
 	pip install -r requirements.txt
+
+dev-deps: dev_requirements.txt
+	pip install -r dev_requirements.txt

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ alert to any or all of:
   * Graphite/StatsD
   * Stackdriver (also known as Google Cloud Monitoring)
   * Alerta (alerting aggregator)
+  * Github Commit Status
 
 You must provide a decrypted `secrets.py` (from the webapp repo) to use
 these services.
@@ -54,7 +55,8 @@ alertlib.Alert("It's time for a walk!")                 \
    .send_to_logs(...)                                   \
    .send_to_graphite(...)                               \
    .send_to_stackdriver(...)                            \
-   .send_to_aggregator(...)
+   .send_to_aggregator(...)                             \
+   .send_to_github_commit_status(...)
 ```
 
 ### Secrets
@@ -71,6 +73,7 @@ google_alertlib_service_account = '{}'
 sendgrid_username = "VALUE"
 sendgrid_password = "VALUE"
 alerta_api_key = "VALUE"
+github_repo_status_deployment_pat = "VALUE"
 ```
 
 You only need to include the secrets for the services you are using.  If you set
@@ -83,6 +86,9 @@ API token), `APP_BOT_TOKEN` (set to bot oauth access token of a Slack app), or
 Most functionality may be used with either, but certain features are only
 supported with the API token.  For this reason we prefer the API token, if both
 are set.
+
+For Github, the `github_repo_status_deployment_pat` must be a personal access
+token that has at least the `repo:status` and `repo_deployment` scopes.
 
 ### HTML formatting (for HipChat and email)
 Alert messages may contain HTML markup if you set the `html=True` parameter on

--- a/alertlib/__init__.py
+++ b/alertlib/__init__.py
@@ -70,7 +70,7 @@ from . import stackdriver    # send_to_stackdriver()
 from . import alerta         # send_to_alerta()
 from . import bugtracker     # send_to_bugtracker()
 from . import jira           # _send_to_jira()
-from . import github         # send_to_send_to_github_commit_status()
+from . import github         # send_to_github_commit_status()
 
 
 class Alert(hipchat.Mixin,

--- a/alertlib/__init__.py
+++ b/alertlib/__init__.py
@@ -13,6 +13,7 @@ USAGE:
        .send_to_logs(...)
        .send_to_graphite(...)
        .send_to_alerta(...)
+       .send_to_github_commit_status(...)
 
 or, if you don't like chaining:
    alert = alertlib.Alert("message")
@@ -31,6 +32,7 @@ The backends supported are:
     * KA Alerta account
     * Logs -- GAE logs on appengine, or syslogs on a unix box
     * Graphite -- update a counter to indicate this alert happened
+    * Github -- for updating a commit status in Github.
 
 You can send an alert to one or more of these.
 
@@ -68,6 +70,7 @@ from . import stackdriver    # send_to_stackdriver()
 from . import alerta         # send_to_alerta()
 from . import bugtracker     # send_to_bugtracker()
 from . import jira           # _send_to_jira()
+from . import github         # send_to_send_to_github_commit_status()
 
 
 class Alert(hipchat.Mixin,
@@ -81,6 +84,7 @@ class Alert(hipchat.Mixin,
             alerta.Mixin,
             jira.Mixin,
             bugtracker.Mixin,
+            github.Mixin,
             BaseMixin):
     """An alert message that can be sent to multiple destinations."""
     # BaseMixin defines __init__.

--- a/alertlib/github.py
+++ b/alertlib/github.py
@@ -62,7 +62,7 @@ class Mixin(base.BaseMixin):
 
         # If no state is provided then we attempt to use the severity
         if not state:
-            if self.severity in 'error':
+            if self.severity == 'error':
                 state = 'error'
             elif self.severity == 'critical':
                 state = 'failure'

--- a/alertlib/github.py
+++ b/alertlib/github.py
@@ -1,0 +1,91 @@
+"""Mixin for Github-related status updates."""
+
+from __future__ import absolute_import
+import json
+import logging
+import six
+
+from . import base
+
+_BASE_GITHUB_API_URL = 'https://api.github.com'
+
+
+def _call_github_api(endpoint, payload_json=None):
+    # This is a separate function just to make it easy to mock for tests.
+    github_api_key = base.secret('github_repo_status_deployment_pat')
+    req = six.moves.urllib.request.Request(_BASE_GITHUB_API_URL + endpoint)
+    req.add_header('Authorization', 'token %s' % github_api_key)
+    req.add_header('Content-Type', 'application/json')
+    req.add_header('Accept', 'application/vnd.github.v3+json')
+    res = six.moves.urllib.request.urlopen(req, payload_json)
+    res_json = res.read()
+
+    if res.getcode() >= 300:
+        raise ValueError(res.read())
+    else:
+        return json.loads(res_json)
+
+
+def _make_github_api_call(endpoint, payload_json=None):
+    """Make a GET or POST request to Github API."""
+    if not base.secret('github_repo_status_deployment_pat'):
+        logging.error("Not sending to Github (no API key found): %s",
+                      payload_json)
+        return
+
+    try:
+        return _call_github_api(endpoint, payload_json)
+    except Exception as e:
+        logging.error("Failed sending %s to Github: %s"
+                      % (payload_json, e))
+
+
+class Mixin(base.BaseMixin):
+    """Mixin for Github API calls."""
+
+    def send_to_github_commit_status(self,
+                                     sha,
+                                     state=None,
+                                     target_url=None,
+                                     description=None,
+                                     context=None,
+                                     owner="Khan",
+                                     repo="webapp"):
+        """Update the status for a particular commit in Github.
+
+        For more information:
+        https://docs.github.com/en/rest/commits/statuses#create-a-commit-status
+        """
+
+        if not self._passed_rate_limit('github_commit_status'):
+            return self
+
+        # If no state is provided then we attempt to use the severity
+        if not state:
+            if self.severity in 'error':
+                state = 'error'
+            elif self.severity == 'critical':
+                state = 'failure'
+            else:
+                state = 'pending'
+
+        payload = {'state': state}
+
+        if target_url:
+            payload['target_url'] = target_url
+        if description:
+            payload['description'] = description
+        if context:
+            payload['context'] = context
+
+        payload_json = json.dumps(payload, sort_keys=True,
+                                  ensure_ascii=False).encode('utf-8')
+
+        if self._in_test_mode():
+            logging.info("alertlib: would send to github commit status: %s"
+                         % (payload_json))
+        else:
+            _make_github_api_call(
+                '/repos/%s/%s/statuses/%s' % (owner, repo, sha), payload_json)
+
+        return self      # so we can chain the method calls

--- a/tests/alertlib_test.py
+++ b/tests/alertlib_test.py
@@ -36,6 +36,7 @@ fake_secrets.sendgrid_low_priority_username = "<sendgrid username>"
 fake_secrets.sendgrid_low_priority_password = "<sendgrid password>"
 fake_secrets.alerta_api_key = '<alerta api key>'
 fake_secrets.jira_api_key = '<jira api key>'
+fake_secrets.github_repo_status_deployment_pat = '<github pat>'
 fake_secrets.APP_BOT_TOKEN = '<slack app bot token>'
 sys.modules['secrets'] = fake_secrets
 
@@ -64,6 +65,7 @@ ALERTLIB_MODULES = (
     'pagerduty',
     'slack',
     'stackdriver',
+    'github',
 )
 for module in ALERTLIB_MODULES:
     importlib.import_module('alertlib.%s' % module)


### PR DESCRIPTION
## Summary:
This adds support for Github Status Checks to Alertlib so that we can call it from Jenkins before/during/after test&lint runs to report the status to Github (allowing them to show up on all of our commits and in all of our pull requests).

The API for this is here:
https://docs.github.com/en/rest/commits/statuses

Issue: FEI-4621.2

## Test plan:
I copied in the `secrets.py` file from Webapp and ran:

```
./alert.py --github-sha=09c3590a92010ca1b21959a42d6170c0e4f7f041 --github-repo=alertlib --summary="Test alert message." --github-target-url="https://www.khanacademy.org/" --github-status=pending
```

And saw the following pending status on the commit I specified:

![Screen Shot 2022-06-22 at 3 49 47 PM](https://user-images.githubusercontent.com/1615/175125955-2e6f0ffd-386e-430e-a077-6276a456877e.jpg)

I also confirmed that clicking "Details" took me to the specified URL.

I also ran the following commands for error, failure, and success and they all worked as expected:

```
./alert.py --github-sha=09c3590a92010ca1b21959a42d6170c0e4f7f041 --github-repo=alertlib --summary="Test alert message." --github-target-url="https://www.khanacademy.org/" --github-status=error
```

![Screen Shot 2022-06-22 at 3 51 23 PM](https://user-images.githubusercontent.com/1615/175126039-f1fc8e9f-cce7-4bb0-817c-e408324b14c8.jpg)


```
./alert.py --github-sha=09c3590a92010ca1b21959a42d6170c0e4f7f041 --github-repo=alertlib --summary="Test alert message." --github-target-url="https://www.khanacademy.org/" --github-status=failure
```

![Screen Shot 2022-06-22 at 3 52 18 PM](https://user-images.githubusercontent.com/1615/175126064-4946d063-069e-4deb-9899-502132318f66.jpg)


```
./alert.py --github-sha=09c3590a92010ca1b21959a42d6170c0e4f7f041 --github-repo=alertlib --summary="Test alert message." --github-target-url="https://www.khanacademy.org/" --github-status=success
```


![Screen Shot 2022-06-22 at 3 50 24 PM](https://user-images.githubusercontent.com/1615/175126015-16173d7a-3694-4f56-a979-f5e67c7f516c.jpg)


Finally I specified a context and saw a non-default name for the runner:
```
./alert.py --github-sha=09c3590a92010ca1b21959a42d6170c0e4f7f041 --github-repo=alertlib --summary="Test alert message." --github-target-url="https://www.khanacademy.org/" --github-status=success --github-context="Jenkins Test"
```
![Screen Shot 2022-06-22 at 3 53 19 PM](https://user-images.githubusercontent.com/1615/175126088-c04990cc-77c0-49b9-b30a-15f02b01edf3.jpg)

